### PR TITLE
Allow flashing on kate device

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -20,8 +20,7 @@
 DEVICE_PATH := device/xiaomi/kenzo
 
 # Assert
-TARGET_OTA_ASSERT_DEVICE := kenzo
-
+TARGET_OTA_ASSERT_DEVICE := kenzo,kate
 # Bluetooth
 BOARD_BLUETOOTH_BDROID_BUILDCFG_INCLUDE_DIR := $(DEVICE_PATH)/bluetooth
 


### PR DESCRIPTION
New TWRP recovery is unified for both kenzo and kate so kenzo ROMs are unable to flash on kate. This change allows them to be flashed on kate (SE version).